### PR TITLE
Try to fix failing ember tests: 'moment' is not defined

### DIFF
--- a/app/models/guess.js
+++ b/app/models/guess.js
@@ -1,4 +1,5 @@
 import DS from 'ember-data';
+import moment from 'moment';
 
 export default DS.Model.extend({
   spot: DS.belongsTo('spot', { async: true }),

--- a/app/models/spot.js
+++ b/app/models/spot.js
@@ -1,4 +1,5 @@
 import DS from 'ember-data';
+import moment from 'moment';
 
 export default DS.Model.extend({
   game: DS.belongsTo('game', { async: true }),


### PR DESCRIPTION
### Motivation

```
$ ember test
models/guess.js: line 9, col 12, 'moment' is not defined.
models/spot.js: line 12, col 12, 'moment' is not defined.
```

I have no idea what I am doing.

There is still one failing test:

```
not ok 16 PhantomJS 2.0 - model:game: it exists
    ---
        actual: >
            null
        message: >
            Died on test #1     at test (http://localhost:7357/assets/test-support.js:1796:15)
                at http://localhost:7357/assets/biketag-admin.js:1894:19
                at http://localhost:7357/assets/vendor.js:150:34
                at tryFinally (http://localhost:7357/assets/vendor.js:30:21)
                at requireModule (http://localhost:7357/assets/vendor.js:148:15)
                at require (http://localhost:7357/assets/test-loader.js:29:16)
                at loadModules (http://localhost:7357/assets/test-loader.js:21:25)
                at load (http://localhost:7357/assets/test-loader.js:40:35)
                at http://localhost:7357/assets/test-support.js:5545:20: No model was found for 'spot'
        Log: >
```
